### PR TITLE
Accessing Array Item by Index

### DIFF
--- a/Text/Hastache/Context.hs
+++ b/Text/Hastache/Context.hs
@@ -250,7 +250,8 @@ convertGenTempToContext v = mkMap "" Map.empty v ~> mkMapContext
         Map.insert (encodeStr name) 
         ([foldl (foldTObj "") Map.empty lst ~> mkMapContext] ~> MuList)
     mkMap name m (TList lst) = Map.insert (encodeStr name) 
-        (map convertGenTempToContext lst ~> MuList) m
+        (map convertGenTempToContext lst ~> MuList)
+        (snd $ foldl (mkListAcc name) (0,m) lst)
     mkMap _ m _ = m
     
     mkName name newName = if length name > 0 
@@ -267,6 +268,8 @@ convertGenTempToContext v = mkMap "" Map.empty v ~> mkMapContext
                         Just a -> a
                 _ -> MuNothing
         Just a -> a
+
+    mkListAcc nm (i,m) fv = (i+1,mkMap (concat [nm, ".", show i]) m fv)
 
 dotBS = encodeStr "."
 


### PR DESCRIPTION
Given a Template:
"{{content.0.name}} and {{content.2.name}}"

And a context:
Resource { content = [ Item { name = "Bob" }, Item { name = "Alice" }, Item { name = "Zoe"} ]

The rendered string would be:
"Bob and Zoe"

As Haskell's identifiers cannot solely consist of numeric characters, the supplied patch does not interfere with the existing generic context-deriving mechanism.
Additionally, accessing array items by their index is apparently already supported in other language implementations of Mustache templates, see https://github.com/janl/mustache.js/issues/158.
