### PR TITLE
Fix ambiquity due to generalised `elem`

### DIFF
--- a/Text/Hastache.hs
+++ b/Text/Hastache.hs
@@ -373,7 +373,7 @@ findCloseSection str name otag ctag = do
     (before, after) = breakOn close str
 
 trimCharsTest :: Char -> Bool
-trimCharsTest = (`Prelude.elem` " \t")
+trimCharsTest = (`Prelude.elem` [' ', '\t'])
 
 trimAll :: Text -> Text
 trimAll = dropAround trimCharsTest


### PR DESCRIPTION
In base-4.8, `elem` has been generalised to `Foldable`, so in
combination with `-XOverloadedStrings`, something like `\c -> elem c "abc"`
can't be type-inferred anymore.

Fixes #41
