### PR TITLE
tests/test.hs: add FlexibleContexts for ghc-7.10

### DIFF
--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Main where
 
 import Control.Monad


### PR DESCRIPTION
Failed to build as:

tests/test.hs:220:5:
    Non type-variable argument in the constraint: MonadWriter T.Text m
    (Use FlexibleContexts to permit this)
    When checking that ‘context’ has the inferred type
      context :: forall (m :: * -> *).
                 MonadWriter T.Text m =>
                 [Char] -> MuType m

Signed-off-by: Sergei Trofimovich <siarheit@google.com>