### PR TITLE
Add Semigroup-instance for MuContext m

### DIFF
--- a/Text/Hastache.hs
+++ b/Text/Hastache.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ExistentialQuantification, FlexibleInstances, IncoherentInstances,
-             OverloadedStrings #-}
+             OverloadedStrings, CPP #-}
 -- Module:      Text.Hastache
 -- Copyright:   Sergey S Lymar (c) 2011-2013 
 -- License:     BSD3
@@ -122,6 +122,17 @@ type MuContext m =
     Text            -- ^ Variable name
     -> m (MuType m) -- ^ Value
 
+#if (MIN_VERSION_base(4,11,0))
+instance (Monad m) => Semigroup (MuContext m) where
+    (<>) a b = \v -> do
+        x <- a v
+        case x of
+            MuNothing -> b v
+            _ -> return x
+instance (Monad m) => Monoid (MuContext m) where
+    mempty = const $ return MuNothing
+    mappend = (<>)
+#else
 instance (Monad m) => Monoid (MuContext m) where
     mempty = const $ return MuNothing
     a `mappend` b = \v -> do
@@ -129,6 +140,8 @@ instance (Monad m) => Monoid (MuContext m) where
         case x of
             MuNothing -> b v
             _ -> return x
+#endif
+
 
 -- | Left-leaning composition of contexts. Given contexts @c1@ and
 -- @c2@, the behaviour of @(c1 <> c2) x@ is following: if @c1 x@

--- a/hastache.cabal
+++ b/hastache.cabal
@@ -1,5 +1,5 @@
 name:            hastache
-version:         0.6.1
+version:         0.6.2
 license:         BSD3
 license-file:    LICENSE
 category:        Text
@@ -27,7 +27,7 @@ extra-source-files:
 executable mkReadme
   main-is: mkReadme.hs
   build-depends: hastache, process,
-    base >=4 && <4.9
+    base >=4 && <5
     ,bytestring
     ,mtl
     ,transformers
@@ -46,7 +46,7 @@ library
     Text.Hastache.Context
 
   build-depends:
-    base >=4.4 && <4.9
+    base >=4.4 && <5
     ,bytestring
     ,mtl
     ,transformers
@@ -69,7 +69,7 @@ test-suite test-hastache
 
   build-depends:
     hastache
-   ,base >=4.4 && <4.9
+   ,base >=4.4 && <5
    ,directory
    ,mtl
    ,HUnit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,15 @@
+resolver: lts-12.2
+
+packages:
+- '.'
+
+# Dependency packages to be pulled from upstream that are not in the resolver
+# (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Main where
 
 import Control.Monad


### PR DESCRIPTION
To support GHC8.4, add semigroup-instance.
GHC8.4 needs semigroup for monoid.
https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid